### PR TITLE
bugfix: in chromium initial class for placing content (movable-conten…

### DIFF
--- a/CommonJS/navMenuCSS.js
+++ b/CommonJS/navMenuCSS.js
@@ -19,6 +19,16 @@ class Navigator{
         this.menuButtons.forEach((button) => {addEventToButton(button)})
     }
 
+    addInitialClassesToElements_chromeBugWorkaround(){
+        // In chrome after clicking a left menu option and hitting F5 page contetn would move left, 
+        // and finally after a few test scenarios page content would be unreachable. Recovery is closing tab and opening once again, as 
+        // page refreshes do not help. setTimeout in adding initial classes is vital for avoiding this bug. Appears only in chromium and chrome.
+        let timePeriod = setTimeout(()=>{
+            this.controlledElement.classList.add('movable-content-0')
+            this.backgroundCanvas.classList.add('movable-background-0')    
+        }, 100);
+    }
+
     indexOfClickedElement(event){
         return Array.from(this.menuButtons).indexOf(event.target)
     }
@@ -49,12 +59,12 @@ class Navigator{
         Array.from(targetElement.classList).forEach((element, index) => {
             if (element.indexOf(pattern) != -1) {oldClassName = element}
         })
-        targetElement.classList.add(newClassName);
         try{
             targetElement.classList.remove(oldClassName);
         } catch {
             // Probably button did not contain this class
         }
+        targetElement.classList.add(newClassName);
     }
 
     clearNavButtonsClicked(){
@@ -76,3 +86,4 @@ class Navigator{
 
 let navigator = new Navigator(document.querySelector('nav'), document.querySelector('.widget-container-wrapper'), document.querySelector('.background-effect-cover'))
 navigator.addEvents();
+navigator.addInitialClassesToElements_chromeBugWorkaround();

--- a/CommonJS/navMenuStyleApplier.js
+++ b/CommonJS/navMenuStyleApplier.js
@@ -39,7 +39,7 @@ class NavigatorStyleApplier {
                 }
                 .movable-background-${i}{
                     transition: left 1s, width 0s;
-                    left: ${(100 * -i) * this.backgroundMoveStepFactor}vw;
+                    left: ${(100 * -i) * this.backgroundMoveStepFactor - 2}vw;
                 }
             `
         }

--- a/index.css
+++ b/index.css
@@ -142,7 +142,6 @@ nav{
 }
 
 .widgets-container{
-    border: black solid thin;
     height: 90vh;
     width: 100vw;
 }


### PR DESCRIPTION
…t-0 or move-background-0) cannot be added from page start. After clicking menu option adding class moving content to left (movable-content-1) and hitting F5 causes page content to move left. After a few scenarios like described page content would be unaveilable. That is why initial classes have to be added with dely. Problem occures only in chrome or chromium browsers